### PR TITLE
Fix detection of bridge IP address

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -140,9 +140,13 @@ func (d *Docker) GetBridgeIP() (string, error) {
 		return "", errors.New("Failed to find network address for bridge network")
 	}
 
-	ip, _, err := net.ParseCIDR(bridge.IPAM.Config[0].Subnet)
+	ip, subnet, err := net.ParseCIDR(bridge.IPAM.Config[0].Subnet)
 	if err != nil {
 		return "", err
+	}
+
+	if subnet.String() != bridge.IPAM.Config[0].Subnet {
+		return ip.String(), nil
 	}
 
 	ipInt := big.NewInt(0)


### PR DESCRIPTION
When Docker is configured to use a specific IP address and netmask for
the default bridge (`--bip=CIDR`), then the `IPAM.Config.Subnet` field
contains the bridge IP address and not the bridge subnet in CIDR notation.

https://github.com/rancher/rancher/issues/5115
